### PR TITLE
ServiceクラスのCREATE処理、UPDATE処理、DELETE処理の単体テストの実装

### DIFF
--- a/src/test/java/com/raisetech/cafeinfo/CafeServiceTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/CafeServiceTest.java
@@ -88,19 +88,14 @@ class CafeServiceTest {
     public void カフェ情報が正常に更新できること() {
         Cafe existingCafe = new Cafe(1, "Starbucks Reserve Roastery", "中目黒", "年中無休", "7時-22時", 300, "シアトル");
         CafeRequest updateRequest = new CafeRequest("オニバスコーヒー", "中目黒", "年中無休", "9時-18時", 12, "奥沢");
+        Cafe expectedUpdatedCafe = new Cafe(1, "オニバスコーヒー", "中目黒", "年中無休", "9時-18時", 12, "奥沢");
 
         doReturn(Optional.of(existingCafe)).when(cafeMapper).findById(1);
         doNothing().when(cafeMapper).updateCafe(any(Cafe.class));
-        Cafe upfatedCafe = cafeService.update(1, updateRequest);
+        Cafe updatedCafe = cafeService.update(1, updateRequest);
+        assertThat(updatedCafe).isEqualTo(expectedUpdatedCafe);
 
-        assertThat(upfatedCafe.getName()).isEqualTo("オニバスコーヒー");
-        assertThat(upfatedCafe.getPlace()).isEqualTo("中目黒");
-        assertThat(upfatedCafe.getRegularHoliday()).isEqualTo("年中無休");
-        assertThat(upfatedCafe.getOpeningHour()).isEqualTo("9時-18時");
-        assertThat(upfatedCafe.getNumberOfSeat()).isEqualTo(12);
-        assertThat(upfatedCafe.getBirthplace()).isEqualTo("奥沢");
-
-        verify(cafeMapper).updateCafe(upfatedCafe);
+        verify(cafeMapper).updateCafe(updatedCafe);
     }
 
     @Test

--- a/src/test/java/com/raisetech/cafeinfo/CafeServiceTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/CafeServiceTest.java
@@ -105,7 +105,7 @@ class CafeServiceTest {
 
     @Test
     public void 存在しないIDのカフェ情報を更新しようとした時に例外がスローされること() {
-        CafeRequest updateRequest = new CafeRequest("Updated Cafe", "Updated Place", "No Holidays", "10:00-20:00", 200, "Updated City");
+        CafeRequest updateRequest = new CafeRequest("オニバスコーヒー", "中目黒", "年中無休", "9時-18時", 12, "奥沢");
 
         doReturn(Optional.empty()).when(cafeMapper).findById(0);
         assertThatThrownBy(() -> cafeService.update(0, updateRequest))


### PR DESCRIPTION
# CREATE、UPDATE、DELETE処理のServiceに対する単体テストを実装

JUnitを用いてCREATE、UPDATE、DELETE処理のServiceに対する単体テストを実装いたしました。

# 単体テスト実施内容

⚫︎CREATE処理
・新しいカフェ情報が正常に登録できること

⚫︎UPDATE処理
・カフェ情報が正常に更新できること
・存在しないIDのカフェ情報を更新しようとした時に例外がスローされること

⚫︎DELETE処理
・カフェ情報が正常に削除できること
・存在しないIDのカフェ情報を削除しようとした時に例外がスローされること

# 実行結果
前回のPRで実装したREAD処理のテストコードを含めTest passed9となり、実装した単体テストが問題なく動作していることを確認しました。

<img width="1282" alt="スクリーンショット 2024-06-13 22 44 12" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/830ce4ce-40c3-408c-bf93-a5ba3eae0bd2">
