### PR TITLE
MapperクラスにCREATE,READ,UPDATE,DELETE処理のDBテストを実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.github.database-rider:rider-spring:1.42.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/raisetech/cafeinfo/CafeMapperTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/CafeMapperTest.java
@@ -1,0 +1,91 @@
+package com.raisetech.cafeinfo;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CafeMapperTest {
+
+    @Autowired
+    CafeMapper cafeMapper;
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml")
+    @Transactional
+    void カフェ情報が全件取得できていること() {
+        List<Cafe> cafes = cafeMapper.findAll();
+        assertThat(cafes)
+                .hasSize(7)
+                .contains(
+                        new Cafe(1, "Starbucks Reserve Roastery", "中目黒", "年中無休", "7時-22時", 300, "シアトル"),
+                        new Cafe(2, "nadoya no katte", "代々木上原", "月、火、水、木", "9時-18時", 15, "代々木上原"),
+                        new Cafe(3, "Streamer Coffee Company", "原宿", "年中無休", "8時-20時", 56, "原宿"),
+                        new Cafe(4, "ブルーボトルコーヒー清澄白河フラッグシップカフェ", "清澄白河", "年中無休", "8時-19時", 47, "カリフォルニア"),
+                        new Cafe(5, "ARC", "蔵前", "年中無休", "平日10時-23時 休日8時半-23時", 52, "蔵前"),
+                        new Cafe(6, "T.Y.HARBOR", "天王洲アイル", "年中無休", "11時半-22時", 350, "天王洲アイル"),
+                        new Cafe(7, "No.13 Cafe", "新宿", "日", "11時-16時半", 30, "新宿")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml")
+    @Transactional
+    void 指定したIDのカフェ情報を取得できること() {
+        Optional<Cafe> actual = cafeMapper.findById(1);
+        assertThat(actual).hasValue(new Cafe(1, "Starbucks Reserve Roastery", "中目黒", "年中無休", "7時-22時", 300, "シアトル"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml")
+    @Transactional
+    void 存在しないIDを指定した場合に空のOptionalが返ること() {
+        Optional<Cafe> actual = cafeMapper.findById(0);
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml")
+    @Transactional
+    void カフェ情報が登録できること() {
+        Cafe newCafe = new Cafe("New Name", "New Place", "New RegularHoliday", "New OpeningHour", 1, "New Birthplace");
+        cafeMapper.insertCafe(newCafe);
+
+        List<Cafe> cafes = cafeMapper.findAll();
+        assertThat(cafes).hasSize(8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml", cleanAfter = true)
+    @Transactional
+    void カフェ情報が更新されていること() {
+        Cafe cafeToUpdate = new Cafe(1, "Updated Cafe", "Updated Place", "Updated RegularHoliday", "Updated OpeningHour", 1, "Updated Birthplace");
+        cafeMapper.updateCafe(cafeToUpdate);
+
+        Optional<Cafe> updatedCafe = cafeMapper.findById(1);
+        assertThat(updatedCafe).isPresent();
+        assertThat(updatedCafe.get()).isEqualTo(cafeToUpdate);
+    }
+
+    @Test
+    @DataSet(value = "datasets/cafes.yml", cleanAfter = true)
+    @Transactional
+    void カフェ情報が削除されていること() {
+        Integer cafeIdToDelete = 1;
+        cafeMapper.deleteCafe(cafeIdToDelete);
+
+        Optional<Cafe> deletedCafe = cafeMapper.findById(cafeIdToDelete);
+        assertThat(deletedCafe).isEmpty();
+    }
+}

--- a/src/test/java/com/raisetech/cafeinfo/CafeMapperTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/CafeMapperTest.java
@@ -61,6 +61,7 @@ class CafeMapperTest {
     void カフェ情報が登録できること() {
         Cafe newCafe = new Cafe("New Name", "New Place", "New RegularHoliday", "New OpeningHour", 1, "New Birthplace");
         cafeMapper.insertCafe(newCafe);
+        assertThat(newCafe.getId()).isNotNull().isGreaterThan(0);
 
         List<Cafe> cafes = cafeMapper.findAll();
         assertThat(cafes).hasSize(8);

--- a/src/test/resources/datasets/cafes.yml
+++ b/src/test/resources/datasets/cafes.yml
@@ -1,0 +1,50 @@
+cafes:
+  - id: 1
+    name: "Starbucks Reserve Roastery"
+    place: "中目黒"
+    regular_holiday: "年中無休"
+    opening_hour: "7時-22時"
+    number_of_seat: 300
+    birthplace: "シアトル"
+  - id: 2
+    name: "nadoya no katte"
+    place: "代々木上原"
+    regular_holiday: "月、火、水、木"
+    opening_hour: "9時-18時"
+    number_of_seat: 15
+    birthplace: "代々木上原"
+  - id: 3
+    name: "Streamer Coffee Company"
+    place: "原宿"
+    regular_holiday: "年中無休"
+    opening_hour: "8時-20時"
+    number_of_seat: 56
+    birthplace: "原宿"
+  - id: 4
+    name: "ブルーボトルコーヒー清澄白河フラッグシップカフェ"
+    place: "清澄白河"
+    regular_holiday: "年中無休"
+    opening_hour: "8時-19時"
+    number_of_seat: 47
+    birthplace: "カリフォルニア"
+  - id: 5
+    name: "ARC"
+    place: "蔵前"
+    regular_holiday: "年中無休"
+    opening_hour: "平日10時-23時 休日8時半-23時"
+    number_of_seat: 52
+    birthplace: "蔵前"
+  - id: 6
+    name: "T.Y.HARBOR"
+    place: "天王洲アイル"
+    regular_holiday: "年中無休"
+    opening_hour: "11時半-22時"
+    number_of_seat: 350
+    birthplace: "天王洲アイル"
+  - id: 7
+    name: "No.13 Cafe"
+    place: "新宿"
+    regular_holiday: "日"
+    opening_hour: "11時-16時半"
+    number_of_seat: 30
+    birthplace: "新宿"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: cafe_database
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/cafe_database"
+  user: "user"
+  password: "password"


### PR DESCRIPTION
# 概要

Database Riderを用いてMapperクラスに対するCREATE、READ、UPDATE、DELETE処理のDBテストを実装いたしました。

# DBテスト実施内容

* CREATE処理
カフェ情報が登録できること

* READ処理
カフェ情報が全件取得できていること
指定したIDのカフェ情報を取得できること
存在しないIDを指定した場合に空のOptionalが返ること

* UPDATE処理
カフェ情報が更新されていること

* DELETE処理
カフェ情報が削除されていること

# 実行結果
全てTests passedとなっており、問題なく作動していることを確認いたしました。

* CREATE処理
<img width="478" alt="スクリーンショット 2024-06-26 17 15 29" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/82fa99a9-6d7d-4d55-aa11-8e324a058df3">

* READ処理
<img width="535" alt="スクリーンショット 2024-06-26 17 14 48" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/9652d8cd-c30f-4988-9692-f158062dc421">

<img width="491" alt="スクリーンショット 2024-06-26 17 15 01" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/2ad1a5a8-d646-4dfb-897c-46bac89c59b0">

<img width="500" alt="スクリーンショット 2024-06-26 17 15 16" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/7c149c6e-b37a-466a-b7cd-91a662e81915">

* UPDATE処理
<img width="494" alt="スクリーンショット 2024-06-26 17 15 48" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/8b41026f-059c-4abd-9de5-b1b0c6047b74">

* DELETE処理
<img width="510" alt="スクリーンショット 2024-06-26 17 15 59" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/9e8e54b2-9b25-4bab-a16e-a416bbf1d813">

 

