### PR TITLE
テスト実行をするワークフローを追加

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -40,6 +40,6 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         if: always()
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -14,15 +14,18 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      - name: Setup DB
+        run: docker compose up -d
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,28 @@
+name: Run Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -30,16 +30,10 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
-      - name: Notify Discord on Success
-        if: success()
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-            -d "{\"content\": \"✅ Build succeeded for commit $(git log -1 --pretty=%B)\"}" \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      - name: Notify Discord on Failure
-        if: failure()
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-            -d "{\"content\": \"❌ Build failed for commit $(git log -1 --pretty=%B)\"}" \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Notify Discord
+        uses: sarisia/actions-status-discord@v1
+        if: always()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          status: ${{ job.status }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
-      - name: Run Test and Notify Discord
+      - name: Notify Discord
         uses: sarisia/actions-status-discord@v1
         if: always()
         env:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -29,3 +29,17 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Notify Discord on Success
+        if: success()
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{\"content\": \"✅ Build succeeded for commit $(git log -1 --pretty=%B)\"}" \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord on Failure
+        if: failure()
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{\"content\": \"❌ Build failed for commit $(git log -1 --pretty=%B)\"}" \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
-      - name: Notify Discord
+      - name: Discord
         uses: sarisia/actions-status-discord@v1
         if: always()
         env:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
-      - name: Notify Discord
+      - name: Run Test and Notify Discord
         uses: sarisia/actions-status-discord@v1
         if: always()
         env:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
       - name: Run Test and Notify Discord
         uses: sarisia/actions-status-discord@v1
         if: always()

--- a/src/test/java/com/raisetech/cafeinfo/integrationtest/CafeApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/integrationtest/CafeApiIntegrationTest.java
@@ -308,6 +308,6 @@ public class CafeApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(String.valueOf(HttpStatus.NOT_FOUND.value())))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("カフェ情報が見つかりません"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/cafes/8"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/cafes/8"))
     }
 }

--- a/src/test/java/com/raisetech/cafeinfo/integrationtest/CafeApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/cafeinfo/integrationtest/CafeApiIntegrationTest.java
@@ -308,6 +308,6 @@ public class CafeApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(String.valueOf(HttpStatus.NOT_FOUND.value())))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("カフェ情報が見つかりません"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/cafes/8"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/cafes/8"));
     }
 }


### PR DESCRIPTION
# 概要
- カフェ情報管理システムにGitHub Actionsによるワークフローを導入しました。
　また、テスト結果をDiscordへ通知を送るCIを追加いたしました。
　
# 動作確認

<img width="917" alt="スクリーンショット 2024-07-11 23 40 42" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/d38a633a-f64b-4f2b-88a3-26b8b4d2c866">

- テスト結果が成功した場合のDiscordの通知

<img width="524" alt="スクリーンショット 2024-07-11 23 36 24" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/7db701ca-bab8-47a3-bf10-59ea58862dcb">


- テスト結果が失敗した場合のDiccordの通知

<img width="493" alt="スクリーンショット 2024-07-11 23 36 52" src="https://github.com/Reiji-Shiode/Cafeinfo-Finalassigment/assets/166202078/34731129-ec52-4101-9b12-5d7e3b5c662f">
